### PR TITLE
Make MD element paragraphs <p> tags, tighter, with more spacing.

### DIFF
--- a/src/components/common/MD.jsx
+++ b/src/components/common/MD.jsx
@@ -22,15 +22,15 @@ const transform = (props) => {
 
 	const paragraph = (text) => {
 
-		return `<div ${stylize({
-			'margin-bottom': comment ? '4px' : '12px',
+		return `<p ${stylize({
+			'margin-bottom': comment ? '1em' : '12px',
 			//'-webkit-font-smoothing': 'antialiased',
 			'color': 'rgba(255,255,255,0.85)',
 			'font-family': 'Lexend-Deca-Regular',
 			'font-size': bio ? '14px' : (comment ? '14px' : '16px'),
-			'line-height': comment ? `21px` : `${EDITOR_LINE_HEIGHT}px`,
+			'line-height': comment ? `1.4` : `${EDITOR_LINE_HEIGHT}px`,
 			...(props.paragraphStyle || {})
-		})}>${text}</div>`;
+		})}>${text}</p>`;
 	};
 
 	r.heading = comment ? paragraph : (text, level) => {


### PR DESCRIPTION
This small change has three effects:

1. Rather than using generic `<div>` elements for paragraphs of text, it uses the semantic `<p>` tag.
2. When `comment` is truthy, the paragraphs' `margin-bottom` is increased from `4px` to `1em`. By setting the margin in `em` units, it will be proportional to the font size (`14px`).
3. When `comment` is truthy, the paragraphs' `line-height` is decreased from `21px` to `1.4` (unitless). By using a unitless value for `line-height`, it will be proportional to the font size (1.4 X 14px = ~19.6px).

The result of these changes is that lines of text in paragraphs are closer together, while blank lines between paragraphs are wider. This groups related text more closely and makes paragraphs more clear.

However, because this change moves away from explicit pixel sizes, it may be controversial.